### PR TITLE
fix: update packages to latest versions and add basic unit tests for the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ mvn clean package
 7. Copy the compiled jar file into the `/usr/local/share/java/` directory:
 
 ```bash
-cp target/kafka-connect-jdbc-sink-0.0.1-SNAPSHOT-jar-with-dependencies.jar /usr/local/share/java/
+cp target/kafka-connect-jdbc-sink-0.0.2-SNAPSHOT-jar-with-dependencies.jar /usr/local/share/java/
 ```
 
 8. Copy the `connect-standalone.properties` and `jdbc-sink.properties` files into the `/usr/local/etc/kafka/` directory.

--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,15 @@
     </repositories>
 
     <properties>
-        <postgresql.version>42.4.1</postgresql.version>
-        <kafka.version>2.3.1</kafka.version>
+        <postgresql.version>42.6.0</postgresql.version>
+        <kafka.version>3.4.0</kafka.version>
         <commons-io.version>2.4</commons-io.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
+        <jcc.version>11.5.8.0</jcc.version>
+        <c3p0.version>0.9.1.2</c3p0.version>
+        <junit-jupiter-engine.version>5.9.3</junit-jupiter-engine.version>
+        <mockito-core.version>5.3.1</mockito-core.version>
+        <slf4j.version>2.0.7</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -96,7 +101,7 @@
         <dependency>
             <groupId>com.ibm.db2</groupId>
             <artifactId>jcc</artifactId>
-            <version>11.5.0.0</version>
+            <version>${jcc.version}</version>
         </dependency>
 
         <dependency>
@@ -114,27 +119,27 @@
         <dependency>
             <groupId>c3p0</groupId>
             <artifactId>c3p0</artifactId>
-            <version>0.9.1.2</version>
+            <version>${c3p0.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.2</version>
+            <version>${junit-jupiter-engine.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>
@@ -82,7 +91,7 @@
         <jcc.version>11.5.8.0</jcc.version>
         <c3p0.version>0.9.1.2</c3p0.version>
         <junit-jupiter-engine.version>5.9.3</junit-jupiter-engine.version>
-        <mockito-core.version>5.3.1</mockito-core.version>
+        <mockito-core.version>4.11.0</mockito-core.version>
         <slf4j.version>2.0.7</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ibm.eventstreams.connect</groupId>
     <artifactId>kafka-connect-jdbc-sink</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
     <name>kafka-connect-jdbc-sink</name>
     <organization>
         <name>IBM Corporation</name>
@@ -79,8 +79,6 @@
     <properties>
         <postgresql.version>42.6.0</postgresql.version>
         <kafka.version>3.4.0</kafka.version>
-        <commons-io.version>2.4</commons-io.version>
-        <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <jcc.version>11.5.8.0</jcc.version>
         <c3p0.version>0.9.1.2</c3p0.version>
         <junit-jupiter-engine.version>5.9.3</junit-jupiter-engine.version>
@@ -141,6 +139,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConfig.java
+++ b/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConfig.java
@@ -117,7 +117,7 @@ public class JDBCSinkConfig extends AbstractConfig {
         return config;
     }
 
-    protected JDBCSinkConfig(final Map<?, ?> props) {
+    public JDBCSinkConfig(final Map<?, ?> props) {
         super(config(), props);
     }
 

--- a/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConnector.java
@@ -33,7 +33,7 @@ public class JDBCSinkConnector extends SinkConnector {
     private static final Logger log = LoggerFactory.getLogger(JDBCSinkConnector.class);
 
     // TODO: check with ibm-messaging about externalizing snapshot version
-    public static String VERSION = "0.0.1-SNAPSHOT";
+    public static String VERSION = "0.0.2-SNAPSHOT";
 
     private Map<String, String> props;
 

--- a/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConnector.java
@@ -22,16 +22,12 @@ import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class JDBCSinkConnector extends SinkConnector {
-    private static final Logger log = LoggerFactory.getLogger(JDBCSinkConnector.class);
-
     // TODO: check with ibm-messaging about externalizing snapshot version
     public static String VERSION = "0.0.2-SNAPSHOT";
 

--- a/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkTask.java
+++ b/src/main/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkTask.java
@@ -30,12 +30,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
 
 public class JDBCSinkTask extends SinkTask {
@@ -46,7 +43,7 @@ public class JDBCSinkTask extends SinkTask {
     //  needs an interface
     private JDBCSinkConfig config;
 
-    private IDatabase database;
+    public IDatabase database;
 
     int remainingRetries; // init max retries via config.maxRetries ...
 

--- a/src/main/java/com/ibm/eventstreams/connect/jdbcsink/database/DatabaseFactory.java
+++ b/src/main/java/com/ibm/eventstreams/connect/jdbcsink/database/DatabaseFactory.java
@@ -19,7 +19,6 @@
 package com.ibm.eventstreams.connect.jdbcsink.database;
 
 import com.ibm.eventstreams.connect.jdbcsink.JDBCSinkConfig;
-import com.ibm.eventstreams.connect.jdbcsink.JDBCSinkTask;
 import com.ibm.eventstreams.connect.jdbcsink.database.datasource.IDataSource;
 import com.ibm.eventstreams.connect.jdbcsink.database.datasource.PooledDataSource;
 import com.ibm.eventstreams.connect.jdbcsink.database.exception.DatabaseNotSupportedException;

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConfigTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConfigTest.java
@@ -1,0 +1,49 @@
+package com.ibm.eventstreams.connect.jdbcsink;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JDBCSinkConfigTest {
+
+    @Test
+    void testValidConfig() {
+        // Create a map with valid configuration properties
+        Map<String, String> props = new HashMap<>();
+        props.put("connection.url", "jdbc:mysql://localhost:3306/mydatabase");
+        props.put("connection.user", "myuser");
+        props.put("connection.password", "mypassword");
+        props.put("table.name.format", "mytable");
+        props.put("connection.ds.pool.size", "5");
+        props.put("insert.mode.databaselevel", "true");
+
+        // Create a new JDBCSinkConfig instance
+        JDBCSinkConfig config = new JDBCSinkConfig(props);
+
+        // Verify the values of the configuration properties
+        assertEquals("jdbc:mysql://localhost:3306/mydatabase", config.getString("connection.url"));
+        assertEquals("myuser", config.getString("connection.user"));
+        assertEquals("mypassword", config.getPassword("connection.password").value());
+        assertEquals("mytable", config.getString("table.name.format"));
+        assertEquals(5, config.getInt("connection.ds.pool.size"));
+        assertTrue(config.getBoolean("insert.mode.databaselevel"));
+    }
+
+    @Test
+    void testMissingRequiredConfig() {
+        // Create a map with missing required configuration properties
+        Map<String, String> props = new HashMap<>();
+        props.put("connection.url", "jdbc:mysql://localhost:3306/mydatabase");
+        props.put("connection.user", "myuser");
+        // Missing "connection.password" and "table.name.format"
+
+        // Create a new JDBCSinkConfig instance and expect a ConfigException to be
+        // thrown
+        assertThrows(ConfigException.class, () -> new JDBCSinkConfig(props));
+    }
+
+}

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConnectorTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkConnectorTest.java
@@ -1,0 +1,75 @@
+package com.ibm.eventstreams.connect.jdbcsink;
+
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JDBCSinkConnectorTest {
+
+    @Mock
+    private Task mockTask;
+
+    private JDBCSinkConnector connector;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        connector = new JDBCSinkConnector();
+    }
+
+    @Test
+    void testTaskClass() {
+        assertEquals(JDBCSinkTask.class, connector.taskClass());
+    }
+
+    @Test
+    void testTaskConfigs() {
+        Map<String, String> props = new HashMap<>();
+        props.put("connection.url", "jdbc:db2://localhost:50000/testdb");
+        props.put("connection.user", "db2inst1");
+        props.put("connection.password", "password");
+        props.put("connection.ds.pool.size", "5");
+        props.put("insert.mode.databaselevel", "true");
+        props.put("table.name.format", "[schema].[table]");
+        props.put("topics", "test");
+        props.put("tasks.max", "1");
+        props.put("connector.class", "com.ibm.eventstreams.connect.jdbcsink.JDBCSinkConnector");
+        connector.start(props);
+        int maxTasks = 2;
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(maxTasks);
+        assertEquals(2, taskConfigs.size());
+        assertEquals(props, taskConfigs.get(0));
+        assertEquals(props, taskConfigs.get(1));
+    }
+
+    @Test
+    void testConfig() {
+        ConfigDef configDef = connector.config();
+        assertEquals(6, configDef.configKeys().size());
+    }
+
+    @Test
+    void testValidate() {
+        JDBCSinkConnector connector = new JDBCSinkConnector();
+        Map<String, String> connConfig = new HashMap<>();
+
+        Config taskConfig = connector.validate(connConfig);
+        assertEquals(6, taskConfig.configValues().size());
+        assertEquals(null, taskConfig.configValues().get(0).value());
+        assertEquals(null, taskConfig.configValues().get(1).value());
+        assertEquals(null, taskConfig.configValues().get(2).value());
+        assertEquals(null, taskConfig.configValues().get(3).value());
+        assertEquals(false, taskConfig.configValues().get(4).value());
+        assertEquals(1, taskConfig.configValues().get(5).value());
+    }
+}

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkTaskTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkTaskTest.java
@@ -31,6 +31,9 @@ class JDBCSinkTaskTest {
         generalConnectorProps.put("connection.url", "jdbc:db2://localhost:50000/sample");
         generalConnectorProps.put("connection.user", "db2inst1");
         generalConnectorProps.put("connection.password", "password");
+
+        task.database = mock(IDatabase.class);
+        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
     }
 
     @Test
@@ -60,9 +63,6 @@ class JDBCSinkTaskTest {
         // Create an empty collection of SinkRecords
         Collection<SinkRecord> records = Collections.emptyList();
 
-        task.database = mock(IDatabase.class);
-        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
-
         // Call the put() method
         task.put(records);
 
@@ -73,8 +73,6 @@ class JDBCSinkTaskTest {
     @Test
     void testStop() {
         // Call the stop() method
-        task.database = mock(IDatabase.class);
-        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
         task.stop();
 
         // Verify that no method invocations were made on the database writer
@@ -89,8 +87,6 @@ class JDBCSinkTaskTest {
         map.put(partition, new OffsetAndMetadata(0));
 
         // Call the flush() method
-        task.database = mock(IDatabase.class);
-        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
         task.flush(map);
 
         // Verify that no method invocations were made on the database writer
@@ -100,28 +96,4 @@ class JDBCSinkTaskTest {
     private void verifyZeroInteractions(IDatabaseWriter writer) {
         verifyNoMoreInteractions(writer);
     }
-
-    // @Test
-    // void testPutSQLException() throws SQLException {
-    // // Create a collection of SinkRecords
-    // Collection<SinkRecord> records = new ArrayList<>();
-    // SinkRecord record = new SinkRecord("topic1", 0, null, null, null, null, 0);
-    // records.add(record);
-
-    // // Configure the configuration properties
-    // Map<String, String> props = generalConnectorProps;
-    // props.put("table.name.format", "mytable");
-
-    // // Call the put() method and expect an exception to be thrown
-    // task.start(props);
-
-    // // Set up the mock behavior to throw an exception
-    // task.database = mock(IDatabase.class);
-    // IDatabaseWriter iDatabaseWriterMock = mock(IDatabaseWriter.class);
-    // Mockito.when(task.database.getWriter()).thenReturn(iDatabaseWriterMock);
-    // doThrow(new SQLException("Write
-    // failed")).when(iDatabaseWriterMock).insert(any(), any());
-
-    // assertThrows(SQLException.class, () -> task.put(records));
-    // }
 }

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkTaskTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/JDBCSinkTaskTest.java
@@ -1,0 +1,127 @@
+package com.ibm.eventstreams.connect.jdbcsink;
+
+import com.ibm.eventstreams.connect.jdbcsink.database.IDatabase;
+import com.ibm.eventstreams.connect.jdbcsink.database.writer.IDatabaseWriter;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.sql.SQLException;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+class JDBCSinkTaskTest {
+
+    private JDBCSinkTask task;
+    private SinkTaskContext context;
+    public Map<String, String> generalConnectorProps = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        task = new JDBCSinkTask();
+        context = mock(SinkTaskContext.class);
+        task.initialize(context);
+
+        // Configure the configuration properties
+        generalConnectorProps.put("table.name.format", "schema.mytable");
+        generalConnectorProps.put("connection.url", "jdbc:db2://localhost:50000/sample");
+        generalConnectorProps.put("connection.user", "db2inst1");
+        generalConnectorProps.put("connection.password", "password");
+    }
+
+    @Test
+    void testPut() throws SQLException {
+        // Call the put() method
+        task.start(generalConnectorProps);
+
+        // Create a collection of SinkRecords
+        Collection<SinkRecord> records = new ArrayList<>();
+        SinkRecord record1 = new SinkRecord("topic1", 0, null, null, null, null, 0);
+        SinkRecord record2 = new SinkRecord("topic1", 1, null, null, null, null, 1);
+        records.add(record1);
+        records.add(record2);
+
+        task.database = mock(IDatabase.class);
+        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
+
+        task.put(records);
+
+        // Verify the method invocations
+        // verify(database.getWriter(), times(1)).insert("mytable", records);
+        verify(task.database.getWriter(), Mockito.times(1)).insert("schema.mytable", records);
+    }
+
+    @Test
+    void testPutEmptyRecords() {
+        // Create an empty collection of SinkRecords
+        Collection<SinkRecord> records = Collections.emptyList();
+
+        task.database = mock(IDatabase.class);
+        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
+
+        // Call the put() method
+        task.put(records);
+
+        // Verify that no method invocations were made on the database writer
+        verifyZeroInteractions(task.database.getWriter());
+    }
+
+    @Test
+    void testStop() {
+        // Call the stop() method
+        task.database = mock(IDatabase.class);
+        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
+        task.stop();
+
+        // Verify that no method invocations were made on the database writer
+        verifyZeroInteractions(task.database.getWriter());
+    }
+
+    @Test
+    void testFlush() {
+        // Create a map of topic partitions and offsets
+        Map<TopicPartition, OffsetAndMetadata> map = new HashMap<>();
+        TopicPartition partition = new TopicPartition("topic1", 0);
+        map.put(partition, new OffsetAndMetadata(0));
+
+        // Call the flush() method
+        task.database = mock(IDatabase.class);
+        Mockito.when(task.database.getWriter()).thenReturn(mock(IDatabaseWriter.class));
+        task.flush(map);
+
+        // Verify that no method invocations were made on the database writer
+        verifyZeroInteractions(task.database.getWriter());
+    }
+
+    private void verifyZeroInteractions(IDatabaseWriter writer) {
+        verifyNoMoreInteractions(writer);
+    }
+
+    // @Test
+    // void testPutSQLException() throws SQLException {
+    // // Create a collection of SinkRecords
+    // Collection<SinkRecord> records = new ArrayList<>();
+    // SinkRecord record = new SinkRecord("topic1", 0, null, null, null, null, 0);
+    // records.add(record);
+
+    // // Configure the configuration properties
+    // Map<String, String> props = generalConnectorProps;
+    // props.put("table.name.format", "mytable");
+
+    // // Call the put() method and expect an exception to be thrown
+    // task.start(props);
+
+    // // Set up the mock behavior to throw an exception
+    // task.database = mock(IDatabase.class);
+    // IDatabaseWriter iDatabaseWriterMock = mock(IDatabaseWriter.class);
+    // Mockito.when(task.database.getWriter()).thenReturn(iDatabaseWriterMock);
+    // doThrow(new SQLException("Write
+    // failed")).when(iDatabaseWriterMock).insert(any(), any());
+
+    // assertThrows(SQLException.class, () -> task.put(records));
+    // }
+}

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/DatabaseFactoryTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/DatabaseFactoryTest.java
@@ -1,0 +1,95 @@
+package com.ibm.eventstreams.connect.jdbcsink.database;
+
+import com.ibm.eventstreams.connect.jdbcsink.JDBCSinkConfig;
+import com.ibm.eventstreams.connect.jdbcsink.database.datasource.IDataSource;
+import com.ibm.eventstreams.connect.jdbcsink.database.exception.DatabaseNotSupportedException;
+import com.ibm.eventstreams.connect.jdbcsink.database.exception.JdbcDriverClassNotFoundException;
+
+import org.apache.kafka.common.config.types.Password;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.beans.PropertyVetoException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DatabaseFactoryTest {
+
+    @Test
+    public void testMakeDatabaseType()
+            throws DatabaseNotSupportedException, JdbcDriverClassNotFoundException, PropertyVetoException {
+        // Set up the configuration
+        // Configure the configuration properties
+        Map<String, String> props = new HashMap<>();
+
+        props.put("table.name.format", "schema.mytable");
+        props.put("connection.user", "db2inst1");
+        props.put("connection.password", "password");
+
+        for (String db : new String[] { "db2", "postgresql", "sqlserver" }) {
+            props.put("connection.url", String.format("jdbc:%s://localhost:50000/sample", db));
+            // Create the database factory
+            DatabaseFactory databaseFactory = new DatabaseFactory();
+
+            JDBCSinkConfig config;
+            config = new JDBCSinkConfig(props);
+
+            // Verify that the database is a expected one
+            if (db.equals("db2")) {
+                IDatabase database = databaseFactory.makeDatabase(config);
+                assertEquals(DatabaseType.db2, database.getType());
+            } else if (db.equals("mysql")) {
+                // catch JdbcDriverClassNotFoundException
+                assertThrows(JdbcDriverClassNotFoundException.class, () -> {
+                    IDatabase database = databaseFactory.makeDatabase(config);
+                    assertEquals(DatabaseType.mysql, database.getType());
+                });
+            } else if (db.equals("postgresql")) {
+                IDatabase database = databaseFactory.makeDatabase(config);
+                assertEquals(DatabaseType.postgresql, database.getType());
+            } else if (db.equals("sqlserver")) {
+                // catch DatabaseNotSupportedException
+                assertThrows(DatabaseNotSupportedException.class, () -> {
+                    databaseFactory.makeDatabase(config);
+                });
+            }
+        }
+    }
+
+    @Test
+    public void testMakeDatabase() {
+        // Prepare test data
+        JDBCSinkConfig config = Mockito.mock(JDBCSinkConfig.class);
+        when(config.getString(JDBCSinkConfig.CONFIG_NAME_CONNECTION_URL)).thenReturn("jdbc:db2://localhost:3306/test");
+        when(config.getString(JDBCSinkConfig.CONFIG_NAME_CONNECTION_USER)).thenReturn("username");
+        when(config.getPassword(JDBCSinkConfig.CONFIG_NAME_CONNECTION_PASSWORD)).thenReturn(new Password("password"));
+        when(config.getInt(JDBCSinkConfig.CONFIG_NAME_CONNECTION_DS_POOL_SIZE)).thenReturn(10);
+
+        // Create a mock for the IDataSource
+        IDataSource dataSource = Mockito.mock(IDataSource.class);
+
+        // Create a mock for the DatabaseType
+        DatabaseType databaseType = Mockito.mock(DatabaseType.class);
+        when(databaseType.getDriver()).thenReturn("com.ibm.db2.jcc.DB2Driver");
+        when(databaseType.create(dataSource)).thenReturn(Mockito.mock(IDatabase.class));
+
+        // Create a mock for the DatabaseFactory
+        DatabaseFactory databaseFactory = Mockito.mock(DatabaseFactory.class);
+        doCallRealMethod().when(databaseFactory).makeDatabase(config);
+
+        // Test the makeDatabase method
+        IDatabase database = databaseFactory.makeDatabase(config);
+
+        // Verify the interactions and assertions
+        verify(config).getString(JDBCSinkConfig.CONFIG_NAME_CONNECTION_URL);
+        verify(config).getString(JDBCSinkConfig.CONFIG_NAME_CONNECTION_USER);
+        verify(config).getPassword(JDBCSinkConfig.CONFIG_NAME_CONNECTION_PASSWORD);
+        verify(config).getInt(JDBCSinkConfig.CONFIG_NAME_CONNECTION_DS_POOL_SIZE);
+        assertNotNull(database);
+    }
+}

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/DatabaseTypeTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/DatabaseTypeTest.java
@@ -1,0 +1,59 @@
+package com.ibm.eventstreams.connect.jdbcsink.database;
+
+import org.junit.jupiter.api.Test;
+
+import com.ibm.eventstreams.connect.jdbcsink.database.datasource.IDataSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DatabaseTypeTest {
+
+    @Test
+    public void testFromJdbcUrl_ValidUrl_ReturnsCorrectDatabaseType() {
+        // Prepare test data
+        String connectionUrl = "jdbc:postgresql://localhost:5432/mydatabase";
+
+        // Test the fromJdbcUrl method
+        DatabaseType result = DatabaseType.fromJdbcUrl(connectionUrl);
+
+        // Verify the result
+        assertEquals(DatabaseType.postgresql, result);
+    }
+
+    @Test
+    public void testFromJdbcUrl_InvalidUrl_ReturnsNull() {
+        // Prepare test data
+        String connectionUrl = "jdbc:oracle://localhost:1521/mydatabase";
+
+        // Test the fromJdbcUrl method
+        DatabaseType result = DatabaseType.fromJdbcUrl(connectionUrl);
+
+        // Verify the result
+        assertNull(result);
+    }
+
+    @Test
+    public void testCreate_ValidDataSource_ReturnsRelationalDatabase() {
+        // Prepare test data
+        IDataSource dataSource = mock(IDataSource.class);
+
+        // Test the create method for each database type
+        for (DatabaseType databaseType : DatabaseType.values()) {
+            IDatabase result = databaseType.create(dataSource);
+
+            // Verify the result
+            assertNotNull(result);
+            assertTrue(result instanceof RelationalDatabase);
+            assertEquals(databaseType, result.getType());
+        }
+    }
+
+    @Test
+    public void testGetDriver_ReturnsCorrectDriver() {
+        // Test the getDriver method for each database type
+        assertEquals("com.ibm.db2.jcc.DB2Driver", DatabaseType.db2.getDriver());
+        assertEquals("org.postgresql.Driver", DatabaseType.postgresql.getDriver());
+        assertEquals("com.mysql.jdbc.Driver", DatabaseType.mysql.getDriver());
+    }
+}

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/datasource/DatabaseTypeTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/datasource/DatabaseTypeTest.java
@@ -16,7 +16,7 @@
  *
  */
 
-package com.ibm.eventstreams.connect.jdbcsink.sink.datasource.database;
+package com.ibm.eventstreams.connect.jdbcsink.database.datasource;
 
 import com.ibm.eventstreams.connect.jdbcsink.database.DatabaseType;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/writer/JDBCWriterTest.java
+++ b/src/test/java/com/ibm/eventstreams/connect/jdbcsink/database/writer/JDBCWriterTest.java
@@ -1,0 +1,129 @@
+package com.ibm.eventstreams.connect.jdbcsink.database.writer;
+
+import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+import com.ibm.db2.jcc.am.DatabaseMetaData;
+import com.ibm.eventstreams.connect.jdbcsink.database.datasource.IDataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+public class JDBCWriterTest {
+
+        @Test
+        public void testCreateTable_TableDoesNotExist_CreatesTable() throws SQLException {
+                // Prepare test data
+                Connection connection = mock(Connection.class);
+                IDataSource dataSource = mock(IDataSource.class);
+                PreparedStatement preparedStatement = mock(PreparedStatement.class);
+                when(dataSource.getConnection()).thenReturn(connection);
+                when(connection.prepareStatement("CREATE TABLE ? (?)")).thenReturn(preparedStatement);
+                // when(connection.getMetaData()).thenReturn(mock(DatabaseMetaData.class));
+
+                String tableName = "test_table";
+
+                Schema schema = SchemaBuilder.struct()
+                                .field("id", Schema.INT32_SCHEMA)
+                                .field("name", Schema.STRING_SCHEMA)
+                                .build();
+
+                JDBCWriter jdbcWriter = new JDBCWriter(dataSource);
+
+                // Execute the method under test
+                jdbcWriter.createTable(connection, tableName, schema);
+
+                // Verify the behavior
+                verify(connection).prepareStatement("CREATE TABLE ? (?)");
+                verify(preparedStatement).execute();
+                verify(preparedStatement).close();
+        }
+
+        @Test
+        public void testInsert_RecordsExist_InsertsRecords() throws SQLException {
+                // Prepare test data
+                Connection connection = mock(Connection.class);
+                IDataSource dataSource = mock(IDataSource.class);
+                DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+                ResultSet resultSet = mock(ResultSet.class);
+                when(dataSource.getConnection()).thenReturn(connection);
+                when(connection.getMetaData()).thenReturn(databaseMetaData);
+                when(databaseMetaData.getTables(any(), any(), any(), any())).thenReturn(resultSet);
+                when(resultSet.next()).thenReturn(true);
+                when(connection.prepareStatement("INSERT INTO ?(?) VALUES (?)"))
+                                .thenReturn(mock(PreparedStatement.class));
+
+                String tableName = "schema.test_table";
+
+                Schema schema = SchemaBuilder.struct()
+                                .field("id", Schema.INT32_SCHEMA)
+                                .field("name", Schema.STRING_SCHEMA)
+                                .build();
+
+                Struct recordValue = new Struct(schema)
+                                .put("id", 1)
+                                .put("name", "John");
+
+                SinkRecord record = new SinkRecord("topic", 0, null, null, schema, recordValue, 0);
+
+                Collection<SinkRecord> records = Collections.singletonList(record);
+
+                JDBCWriter jdbcWriter = new JDBCWriter(dataSource);
+
+                // Execute the method under test
+                jdbcWriter.insert(tableName, records);
+
+                // Verify the behavior
+                verify(connection).prepareStatement("INSERT INTO ?(?) VALUES (?)");
+                verify(connection).close();
+        }
+
+        @Test
+        public void testInsert_RecordsExist_CreateAndInsertsRecords() throws SQLException {
+                // Prepare test data
+                Connection connection = mock(Connection.class);
+                IDataSource dataSource = mock(IDataSource.class);
+                DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+                ResultSet resultSet = mock(ResultSet.class);
+                PreparedStatement preparedStatement = mock(PreparedStatement.class);
+                when(dataSource.getConnection()).thenReturn(connection);
+                when(connection.getMetaData()).thenReturn(databaseMetaData);
+                when(databaseMetaData.getTables(any(), any(), any(), any())).thenReturn(resultSet);
+                when(resultSet.next()).thenReturn(false);
+                when(connection.prepareStatement("INSERT INTO ?(?) VALUES (?)"))
+                                .thenReturn(mock(PreparedStatement.class));
+                when(connection.prepareStatement("CREATE TABLE ? (?)")).thenReturn(preparedStatement);
+
+                String tableName = "schema.test_table";
+
+                Schema schema = SchemaBuilder.struct()
+                                .field("id", Schema.INT32_SCHEMA)
+                                .field("name", Schema.STRING_SCHEMA)
+                                .build();
+
+                Struct recordValue = new Struct(schema)
+                                .put("id", 1)
+                                .put("name", "John");
+
+                SinkRecord record = new SinkRecord("topic", 0, null, null, schema, recordValue, 0);
+
+                Collection<SinkRecord> records = Collections.singletonList(record);
+
+                JDBCWriter jdbcWriter = new JDBCWriter(dataSource);
+
+                // Execute the method under test
+                jdbcWriter.insert(tableName, records);
+
+                // Verify the behavior
+                verify(connection).prepareStatement("INSERT INTO ?(?) VALUES (?)");
+                verify(connection).prepareStatement("CREATE TABLE ? (?)");
+                verify(connection).close();
+        }
+}


### PR DESCRIPTION
- Adding new 19 tests

```bash
[INFO] --------< com.ibm.eventstreams.connect:kafka-connect-jdbc-sink >--------
[INFO] Building kafka-connect-jdbc-sink 0.0.2
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The artifact org.slf4j:slf4j-log4j12:jar:2.0.7 has been relocated to org.slf4j:slf4j-reload4j:jar:2.0.7
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ kafka-connect-jdbc-sink ---
[WARNING] The artifact xml-apis:xml-apis:jar:2.0.2 has been relocated to xml-apis:xml-apis:jar:1.0.b2
[INFO] com.ibm.eventstreams.connect:kafka-connect-jdbc-sink:jar:0.0.2
[INFO] +- org.postgresql:postgresql:jar:42.6.0:compile
[INFO] |  \- org.checkerframework:checker-qual:jar:3.31.0:runtime
[INFO] +- com.ibm.db2:jcc:jar:11.5.8.0:compile
[INFO] +- org.apache.kafka:connect-api:jar:3.4.0:compile
[INFO] |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:runtime
[INFO] +- org.apache.kafka:kafka-clients:jar:3.4.0:compile
[INFO] |  +- com.github.luben:zstd-jni:jar:1.5.2-1:runtime
[INFO] |  +- org.lz4:lz4-java:jar:1.8.0:runtime
[INFO] |  \- org.xerial.snappy:snappy-java:jar:1.1.8.4:runtime
[INFO] +- c3p0:c3p0:jar:0.9.1.2:compile
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.9.3:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.9.3:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.9.3:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.9.3:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- org.mockito:mockito-core:jar:4.11.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.12.19:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.12.19:test
[INFO] |  \- org.objenesis:objenesis:jar:3.3:test
[INFO] +- org.slf4j:slf4j-reload4j:jar:2.0.7:test
[INFO] |  \- ch.qos.reload4j:reload4j:jar:1.2.22:test
[INFO] \- org.slf4j:slf4j-api:jar:2.0.7:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.863 s
[INFO] Finished at: 2023-06-02T17:04:42+05:30
[INFO] ------------------------------------------------------------------------

```